### PR TITLE
Implement ACF-powered hero panel in mega menu

### DIFF
--- a/themes/peugeot-theme/custom.css
+++ b/themes/peugeot-theme/custom.css
@@ -2355,11 +2355,20 @@ li.menu-item.menu-item-type-custom.menu-item-object-custom.menu-item a {
 }
 
 /* Bên trong panel: grid căn giữa, max-width để không quá dài */
-.peugeot-main-nav .mega-panel>.mega-grid {
+.peugeot-main-nav .mega-panel .pg-mega-wrapper {
     max-width: 1440px;
     /* hoặc 1280px tuỳ bạn */
     margin: 0 auto;
     padding: 0 24px 24px;
+    display: flex;
+    gap: 32px;
+    align-items: stretch;
+}
+
+.pg-mega-left .mega-grid {
+    margin: 0;
+    padding: 16px 0 24px;
+    list-style: none;
     display: grid;
     gap: 24px;
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
@@ -2843,11 +2852,120 @@ li.year-item {
     font-size: 10px;
 }
 }
-.pg-mega-wrapper{display:flex;min-height:calc(100vh - 60px)}
-.pg-mega-left{flex:1 1 55%;padding:24px;overflow:auto;background:#fff}
-.pg-mega-right{flex:1 1 45%;position:relative;min-height:60vh;background:#f3f4f6}
-.pg-mega-hero{position:absolute;inset:0;background-size:cover;background-position:center;display:flex;flex-direction:column;justify-content:flex-end;align-items:flex-start;padding:24px}
-.pg-mega-hero-title{color:#fff;font-weight:800;font-size:28px;margin:0 0 12px;text-transform:uppercase;letter-spacing:.04em;text-shadow:0 2px 10px rgba(0,0,0,.35)}
-.pg-mega-hero-btn{display:inline-block;padding:14px 22px;background:#0a67ff;color:#fff;font-weight:700;border-radius:6px;text-decoration:none}
-.pg-mega-hero-btn:hover{filter:brightness(1.05)}
-@media (max-width:991.98px){.pg-mega-wrapper{flex-direction:column}.pg-mega-right{min-height:40vh}}
+.pg-mega-wrapper{
+    display: flex;
+    min-height: calc(100vh - var(--pg-header-h));
+    width: 100%;
+    gap: 32px;
+}
+
+.pg-mega-wrapper--no-hero .pg-mega-right {
+    display: none;
+}
+
+.pg-mega-wrapper--no-hero .pg-mega-left {
+    flex: 1 1 100%;
+    max-width: 100%;
+}
+
+.pg-mega-left{
+    flex: 0 0 60%;
+    max-width: 60%;
+    padding: 16px 8px 16px 0;
+    overflow-y: auto;
+    background: transparent;
+}
+
+.pg-mega-right{
+    flex: 1 1 40%;
+    position: relative;
+    min-height: 60vh;
+    background: #f3f4f6;
+    border-radius: 20px;
+    overflow: hidden;
+}
+
+.pg-mega-hero{
+    position: absolute;
+    inset: 0;
+    background-size: cover;
+    background-position: center;
+    background-color: #0a1428;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: flex-start;
+    padding: 32px;
+    gap: 12px;
+    color: #fff;
+}
+
+.pg-mega-hero::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, rgba(7, 14, 29, 0.1) 0%, rgba(7, 14, 29, 0.75) 100%);
+    opacity: .9;
+}
+
+.pg-mega-hero > * {
+    position: relative;
+    z-index: 1;
+}
+
+.pg-mega-hero-title{
+    color: #fff;
+    font-weight: 800;
+    font-size: 28px;
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+    text-shadow: 0 2px 10px rgba(0,0,0,.35);
+}
+
+.pg-mega-hero-text {
+    color: #fff;
+    font-size: 16px;
+    line-height: 1.5;
+    margin: 0;
+    opacity: .9;
+}
+
+.pg-mega-hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 4px;
+}
+
+.pg-mega-hero-btn{
+    display: inline-block;
+    padding: 14px 22px;
+    background: #0a67ff;
+    color: #fff;
+    font-weight: 700;
+    border-radius: 6px;
+    text-decoration: none;
+    transition: filter .2s ease;
+}
+
+.pg-mega-hero-btn:hover{
+    filter: brightness(1.05);
+}
+
+@media (max-width:991.98px){
+    .pg-mega-wrapper{
+        flex-direction: column;
+    }
+    .pg-mega-left,
+    .pg-mega-right{
+        flex: 1 1 100%;
+        max-width: 100%;
+    }
+    .pg-mega-left{
+        padding: 16px 0;
+    }
+    .pg-mega-right{
+        min-height: 40vh;
+    }
+}


### PR DESCRIPTION
## Summary
- restructure the mega menu walker to wrap child items with a two-column mega panel layout
- pull hero imagery, copy, and CTAs from the `mega_panel` ACF group on each top-level menu item
- refresh mega panel styling to present a 60/40 grid with the WordPress menu on the left and the hero block on the right

## Testing
- php -l themes/peugeot-theme/functions.php

------
https://chatgpt.com/codex/tasks/task_e_68cad5b5c5108320b1ed238472fe6263